### PR TITLE
[KLC-1438] Replace klever.finance with klever.org

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	api           = "https://api.mainnet.klever.finance"
+	api           = "https://api.mainnet.klever.org"
 	txListPath    = "transaction/list"
 	assetsPath    = "assets"
 	kleverscanURL = "https://kleverscan.org/transaction/"


### PR DESCRIPTION
This PR updates all references from the legacy `.finance` domain to the new `.org` domain. The `.finance` domain will be decommissioned at the end of April, making this change necessary to ensure continued functionality